### PR TITLE
Add Serde support and a couple more things

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # `versions` Changelog
 
+## 2.2.0 (2021-04-13)
+
+#### Added
+
+- [`Serde`](https://serde.rs/) support through the `serde` feature.
+- `Versioning::nth` has been added.
+- `Default` has been derived on `Versioning`, `SemVer`, `Version`, `Mess` and `Chunks`
+  so that it's possible to initialize as a struct's field.
+
 ## 2.1.0 (2021-03-22)
 
 #### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "versions"
-version = "2.1.0"
+version = "2.2.0"
 authors = ["Colin Woodbury <colin@fosskers.ca>"]
 edition = "2018"
 description = "A library for parsing and comparing software version numbers."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["parser-implementations"]
 [dependencies]
 nom = "6.0"
 itertools = "0.10"
+serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]
 version-sync = "0.9"

--- a/README.md
+++ b/README.md
@@ -32,3 +32,8 @@ assert!(good.is_ideal());   // It parsed as a `SemVer`.
 assert!(evil.is_complex()); // It parsed as a `Mess`.
 assert!(good > evil);       // We can compare them anyway!
 ```
+
+### Features
+
+You can enable [`Serde`](https://serde.rs/) support for serialization and
+deserialization with the `serde` feature.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1109,7 +1109,40 @@ impl Versioning {
             _ => false,
         }
     }
+
+    /// Try to extract a position from the `Versioning` as a nice integer, as if it
+    /// were a [`SemVer`].
+    ///
+    /// ```
+    /// use versions::Versioning;
+    ///
+    /// let semver = Versioning::new("1.2.3-r1+git123").unwrap();
+    /// assert!(semver.is_ideal());
+    /// assert_eq!(Some(1), semver.nth(0));
+    /// assert_eq!(Some(2), semver.nth(1));
+    /// assert_eq!(Some(3), semver.nth(2));
+    ///
+    /// let version = Versioning::new("1:2.a.4.5.6.7-r1").unwrap();
+    /// assert!(version.is_general());
+    /// assert_eq!(Some(2), version.nth(0));
+    /// assert_eq!(None, version.nth(1));
+    /// assert_eq!(Some(4), version.nth(2));
+    ///
+    /// let mess = Versioning::new("1.6a.0+2014+m872b87e73dfb-1").unwrap();
+    /// assert!(mess.is_complex());
+    /// assert_eq!(Some(1), mess.nth(0));
+    /// assert_eq!(None, mess.nth(1));
+    /// assert_eq!(Some(0), mess.nth(2));
+    /// ```
+    pub fn nth(&self, n: usize) -> Option<u32> {
+        match self {
+            Versioning::Ideal(s) => s.to_version().nth(n),
+            Versioning::General(v) => v.nth(n),
+            Versioning::Complex(m) => m.nth(n),
+        }
+    }
 }
+
 impl PartialOrd for Versioning {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,8 @@ use nom::character::complete::{alpha1, alphanumeric1, char, digit1};
 use nom::combinator::{map, map_res, opt, peek, recognize, value};
 use nom::multi::{many1, separated_list1};
 use nom::IResult;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::cmp::Ordering::{Equal, Greater, Less};
 use std::fmt;
@@ -83,6 +85,7 @@ mod parsers;
 /// ```
 ///
 /// [semver]: http://semver.org
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Eq, Hash, Clone, Default)]
 pub struct SemVer {
     pub major: u32,
@@ -333,6 +336,7 @@ impl fmt::Display for SemVer {
 ///     assert!(Version::new(v).is_some());
 /// }
 /// ```
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Default)]
 pub struct Version {
     pub epoch: Option<u32>,
@@ -553,6 +557,7 @@ impl fmt::Display for Version {
 /// assert!(v.is_none());
 /// assert_eq!(Some(mess.to_string()), m.map(|v| format!("{}", v)));
 /// ```
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Default)]
 pub struct Mess {
     pub chunks: Vec<MChunk>,
@@ -665,6 +670,7 @@ impl fmt::Display for Mess {
 /// A numeric value is extracted if it could be, alongside the original text it
 /// came from. This preserves both `Ord` and `Display` behaviour for versions
 /// like `1.003.0`.
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub enum MChunk {
     /// A nice numeric value.
@@ -755,6 +761,7 @@ impl fmt::Display for MChunk {
 /// - A hyphen (-).
 /// - A plus (+). Stop using this outside of metadata if you are. Example: `10.2+0.93+1-1`
 /// - An underscore (_). Stop using this if you are.
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub enum Sep {
     Colon,
@@ -782,6 +789,7 @@ impl fmt::Display for Sep {
 ///
 /// Please avoid using the `Unit::Letters` constructor yourself. Instead
 /// consider the [`Unit::from_string`] method to verify the input.
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
 pub enum Unit {
     Digits(u32),
@@ -839,6 +847,7 @@ impl fmt::Display for Unit {
 /// - `r3`
 /// - `0rc1`
 /// - `20150826`
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct Chunk(pub Vec<Unit>);
 
@@ -993,6 +1002,7 @@ impl fmt::Display for Chunk {
 ///
 /// Defined as a newtype wrapper so that we can define custom parser and trait
 /// methods.
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Default)]
 pub struct Chunks(pub Vec<Chunk>);
 
@@ -1069,6 +1079,7 @@ impl fmt::Display for Chunks {
 /// assert!(b.is_general());
 /// assert!(c.is_complex());
 /// ```
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub enum Versioning {
     Ideal(SemVer),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@ mod parsers;
 /// ```
 ///
 /// [semver]: http://semver.org
-#[derive(Debug, Eq, Hash, Clone)]
+#[derive(Debug, Eq, Hash, Clone, Default)]
 pub struct SemVer {
     pub major: u32,
     pub minor: u32,
@@ -333,7 +333,7 @@ impl fmt::Display for SemVer {
 ///     assert!(Version::new(v).is_some());
 /// }
 /// ```
-#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Default)]
 pub struct Version {
     pub epoch: Option<u32>,
     pub chunks: Chunks,
@@ -553,7 +553,7 @@ impl fmt::Display for Version {
 /// assert!(v.is_none());
 /// assert_eq!(Some(mess.to_string()), m.map(|v| format!("{}", v)));
 /// ```
-#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Default)]
 pub struct Mess {
     pub chunks: Vec<MChunk>,
     pub next: Option<(Sep, Box<Mess>)>,
@@ -993,7 +993,7 @@ impl fmt::Display for Chunk {
 ///
 /// Defined as a newtype wrapper so that we can define custom parser and trait
 /// methods.
-#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Default)]
 pub struct Chunks(pub Vec<Chunk>);
 
 impl Chunks {
@@ -1147,6 +1147,12 @@ impl fmt::Display for Versioning {
             Versioning::General(v) => write!(f, "{}", v),
             Versioning::Complex(m) => write!(f, "{}", m),
         }
+    }
+}
+
+impl Default for Versioning {
+    fn default() -> Self {
+        Self::Ideal(SemVer::default())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,8 +38,13 @@
 //! In constructing your own [`nom`](https://lib.rs/nom) parsers, you can
 //! integrate the parsers used for the types in this crate via
 //! [`SemVer::parse`], [`Version::parse`], and [`Mess::parse`].
+//!
+//! ### Features
+//!
+//! You can enable [`Serde`](https://serde.rs/) support for serialization and
+//! deserialization with the `serde` feature.
 
-#![doc(html_root_url = "https://docs.rs/versions/2.1.0")]
+#![doc(html_root_url = "https://docs.rs/versions/2.2.0")]
 
 use itertools::EitherOrBoth::{Both, Left, Right};
 use itertools::Itertools;


### PR DESCRIPTION
Your crate was just what I needed, but it didn't have Serde support, so I added it. It's behind a feature, so only those who need it will pull `serde` as a dependency.

I also added a couple of small things I needed to make my own code work and I think they are good additions here.

One is deriving `Default` on the major structs so they can be initialized as struct fields and mutated as needed. I use this particular way in my own code a lot.

The other is adding the `nth` method for `Versioning`. I was trying to use `Version` to parse everything since it's a pretty ancient program (Blender), but exactly one version (2.04alpha) just broke it because of the leading zero. And I needed the ability to compare major and minor numbers of LTS releases (which now follow SemVer) in my code to do some stuff, so I added this.

I tried to follow your style as much as possible, but do tell me if something needs to be changed. Or change it yourself if preferred.