### PR TITLE
Add versioning requirement with operation and constraint matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # `versions` Changelog
 
+## Unreleased
+
+#### Added
+
+- The `Requirement` type for testing version constraints.
+- `Versioning::parse` for usage with `nom`.
+- `Versioning::deserialize_pretty` for deserializing directly from raw version strings.
+
 ## 6.0.0 (2023-12-06)
 
 While technically a breaking change, most users should not notice.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,4 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 version-sync = "0.9"
 semver = "1.0"
 semver-parser = "0.10"
+serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,13 @@ categories = ["parser-implementations"]
 [dependencies]
 itertools = "0.12"
 nom = "7.1"
-semver = "1.0"
+semver = { version = "1.0", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]
 version-sync = "0.9"
 semver = "1.0"
 semver-parser = "0.10"
+
+[features]
+semver = ["dep:semver"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,9 @@ categories = ["parser-implementations"]
 [dependencies]
 itertools = "0.12"
 nom = "7.1"
-semver = { version = "1.0", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]
 version-sync = "0.9"
 semver = "1.0"
 semver-parser = "0.10"
-
-[features]
-semver = ["dep:semver"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["parser-implementations"]
 [dependencies]
 itertools = "0.12"
 nom = "7.1"
+semver = "1.0"
 serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -3,13 +3,15 @@
 [![Tests](https://github.com/fosskers/rs-versions/workflows/Tests/badge.svg)](https://github.com/fosskers/rs-versions/actions)
 [![](https://img.shields.io/crates/v/versions.svg)](https://crates.io/crates/versions)
 
+<!-- cargo-rdme start -->
+
 A library for parsing and comparing software version numbers.
 
-We like to give version numbers to our software in a myriad of different ways.
-Some ways follow strict guidelines for incrementing and comparison. Some follow
-conventional wisdom and are generally self-consistent. Some are just plain
-asinine. This library provides a means of parsing and comparing *any* style of
-versioning, be it a nice Semantic Version like this:
+We like to give version numbers to our software in a myriad of different
+ways. Some ways follow strict guidelines for incrementing and comparison.
+Some follow conventional wisdom and are generally self-consistent. Some are
+just plain asinine. This library provides a means of parsing and comparing
+*any* style of versioning, be it a nice Semantic Version like this:
 
 > 1.2.3-r1
 
@@ -17,10 +19,15 @@ versioning, be it a nice Semantic Version like this:
 
 > 2:10.2+0.0093r3+1-1
 
-For the Haskell version of this library, [see
-here](http://hackage.haskell.org/package/versions).
+## Usage
 
-### Examples
+If you're parsing several version numbers that don't follow a single scheme
+(say, as in system packages), then use the [`Versioning`] type and its
+parser [`Versioning::new`]. Otherwise, each main type - [`SemVer`],
+[`Version`], or [`Mess`] - can be parsed on their own via the `new` method
+(e.g. [`SemVer::new`]).
+
+## Examples
 
 ```rust
 use versions::Versioning;
@@ -33,7 +40,39 @@ assert!(evil.is_complex()); // It parsed as a `Mess`.
 assert!(good > evil);       // We can compare them anyway!
 ```
 
-### Features
+## Version Constraints
+
+Tools like `cargo` also allow version constraints to be prepended to a
+version number, like in `^1.2.3`.
+
+```rust
+use versions::{Requirement, Versioning};
+
+let req = Requirement::new("^1.2.3").unwrap();
+let ver = Versioning::new("1.2.4").unwrap();
+assert!(req.matches(&ver));
+```
+
+In this case, the incoming version `1.2.4` satisfies the "caret" constraint,
+which demands anything greater than or equal to `1.2.3`.
+
+See the [`Requirement`] type for more details.
+
+## Usage with `nom`
+
+In constructing your own [`nom`](https://lib.rs/nom) parsers, you can
+integrate the parsers used for the types in this crate via
+[`Versioning::parse`], [`SemVer::parse`], [`Version::parse`], and
+[`Mess::parse`].
+
+## Features
 
 You can enable [`Serde`](https://serde.rs/) support for serialization and
 deserialization with the `serde` feature.
+
+By default the version structs are serialized/deserialized as-is. If instead
+you'd like to deserialize directly from a raw version string like `1.2.3`,
+see [`Versioning::deserialize_pretty`].
+
+<!-- cargo-rdme end -->
+


### PR DESCRIPTION
This PR adds a new struct `VersioningReq`, an analogue to `VersionReq` from `semver` but using `Versioning`s instead. This makes it easier to use `Versioning` when interpreting dependency version requirements for non-Rust languages and frameworks.

This PR is fairly complete, it includes documentation, tests, doctests, etc. Happy to discuss/change anything if needed.