### PR TITLE
add Requirements::serialize method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # `versions` Changelog
 
+## Unreleased
+
+#### Added
+
+- `Requirement::serialize` for pretty-encoding of version "requirements strings".
+
 ## 6.1.0 (2024-01-12)
 
 #### Added

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1729,7 +1729,7 @@ impl Requirement {
 
     #[cfg(feature = "serde")]
     /// Function suitable for use as a custom serde serializer for
-    /// the `Requirment` struct.
+    /// the `Requirment` type.
     ///
     /// ```rust
     /// use versions::Requirement;
@@ -1748,7 +1748,7 @@ impl Requirement {
     where
         S: Serializer,
     {
-        let s: String = format!("{}", self);
+        let s: String = self.to_string();
         serializer.serialize_str(&s)
     }
 }


### PR DESCRIPTION
I wanted to be able to serialize the Requirement Structs, so I went ahead and quickly added that. To this end I used the display, which is already implemented for that struct. 

- [x] added unit test which checks if the serializer works
- [x] added doc strings