### PR TITLE
Let version parsers fail on rest len

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -702,6 +702,72 @@ mod tests {
         assert!(bad.is_complex());
     }
 
+    // https://github.com/fosskers/rs-versions/issues/33
+    //
+    // A version with more parts than a `SemVer` (here a four-part Windows-style
+    // version) parses fine on its own, but used to fail inside a `Requirement`.
+    // `Requirement::parse` delegates its version tail to `Versioning::parse`,
+    // which greedily accepted the three-part SemVer prefix `10.1.22000` and left
+    // `.832` behind, so `Requirement::new`'s full-consumption check failed.
+    #[test]
+    fn versions_33() {
+        let version = Versioning::new("10.1.22000.832").unwrap();
+        assert!(version.is_general());
+
+        // Each of these requirements must now actually parse.
+        for r in [
+            "<10.1.22000",
+            ">10.1.22000",
+            "<10.1.22000.832",
+            ">10.1.22000.832",
+        ] {
+            assert!(
+                Requirement::new(r).is_some(),
+                "requirement failed to parse: {r}"
+            );
+        }
+
+        // And the comparisons they enable should be sane.
+        assert!(!Requirement::new("<10.1.22000").unwrap().matches(&version));
+        assert!(Requirement::new(">10.1.22000").unwrap().matches(&version));
+        // The version is neither strictly less nor greater than itself.
+        assert!(
+            !Requirement::new("<10.1.22000.832")
+                .unwrap()
+                .matches(&version)
+        );
+        assert!(
+            !Requirement::new(">10.1.22000.832")
+                .unwrap()
+                .matches(&version)
+        );
+        assert!(
+            Requirement::new(">=10.1.22000.832")
+                .unwrap()
+                .matches(&version)
+        );
+    }
+
+    // NodeJS / Debian-style versions that use `++` and `+~` as separators. These
+    // are too irregular to be a `SemVer` or `Version`, so they land as a `Mess`,
+    // and must round-trip losslessly through `Display`.
+    #[test]
+    fn nodejs_messes() {
+        for s in [
+            "6.0.1+~3.0.4+~2.0.0+~1.0.0+~2.0.1-1",
+            "0.7.0++dfsg2+really.0.6.1-15",
+        ] {
+            let v = Versioning::new(s).unwrap_or_else(|| panic!("failed to parse: {s}"));
+            assert!(v.is_complex(), "{s} should be complex, got {v:?}");
+            assert_eq!(s, v.to_string(), "round-trip failed for {s}");
+        }
+
+        // Ordering still works across these messes.
+        let a = Versioning::new("6.0.1+~3.0.4+~2.0.0+~1.0.0+~2.0.1-1").unwrap();
+        let b = Versioning::new("6.0.2+~3.0.4+~2.0.0+~1.0.0+~2.0.1-1").unwrap();
+        assert!(a < b);
+    }
+
     // https://github.com/fosskers/aura/issues/876
     #[test]
     fn aura_876() {

--- a/src/mess.rs
+++ b/src/mess.rs
@@ -131,6 +131,8 @@ impl Mess {
 
     fn sep(i: &str) -> IResult<&str, Sep> {
         alt((
+            value(Sep::PlusPlus, tag("++")),
+            value(Sep::PlusTilde, tag("+~")),
             value(Sep::Colon, char(':')),
             value(Sep::Hyphen, char('-')),
             value(Sep::Plus, char('+')),
@@ -309,16 +311,22 @@ pub enum Sep {
     Underscore,
     /// `~`
     Tilde,
+    /// `+~`
+    PlusTilde,
+    /// `++`
+    PlusPlus,
 }
 
 impl std::fmt::Display for Sep {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         let c = match self {
-            Sep::Colon => ':',
-            Sep::Hyphen => '-',
-            Sep::Plus => '+',
-            Sep::Underscore => '_',
-            Sep::Tilde => '~',
+            Sep::Colon => ":",
+            Sep::Hyphen => "-",
+            Sep::Plus => "+",
+            Sep::Underscore => "_",
+            Sep::Tilde => "~",
+            Sep::PlusTilde => "+~",
+            Sep::PlusPlus => "++",
         };
         write!(f, "{}", c)
     }

--- a/src/versioning.rs
+++ b/src/versioning.rs
@@ -4,7 +4,7 @@ use std::cmp::Ordering;
 
 use crate::{Error, Mess, SemVer, Version};
 use nom::IResult;
-use nom::combinator::map;
+use nom::combinator::{all_consuming, map};
 use nom::{Parser, branch::alt};
 use std::str::FromStr;
 
@@ -57,9 +57,9 @@ impl Versioning {
     /// combination with other general `nom` parsers.
     pub fn parse(i: &str) -> IResult<&str, Versioning> {
         alt((
-            map(SemVer::parse, Versioning::Ideal),
-            map(Version::parse, Versioning::General),
-            map(Mess::parse, Versioning::Complex),
+            map(all_consuming(SemVer::parse), Versioning::Ideal),
+            map(all_consuming(Version::parse), Versioning::General),
+            map(all_consuming(Mess::parse), Versioning::Complex),
         ))
         .parse(i)
     }


### PR DESCRIPTION
This way the Versioning::parse method actually jumps to the next parser in the list if the previous one was unable to parse the input.